### PR TITLE
[READY] Fix S3 hostname issue

### DIFF
--- a/lib/spurious/server/state/factory.rb
+++ b/lib/spurious/server/state/factory.rb
@@ -14,7 +14,7 @@ module Spurious
         def self.create(type, connection, config, options)
           case type.to_sym
           when :init
-            Init.new(connection, config)
+            Init.new(connection, config, options.docker_host)
           when :start
             Start.new(connection, config, options.docker_host)
           when :stop

--- a/lib/spurious/server/state/start.rb
+++ b/lib/spurious/server/state/start.rb
@@ -7,11 +7,11 @@ module Spurious
   module Server
     module State
       class Start < Base
-        attr_accessor :docker_host_ip
+        attr_accessor :docker_host
 
-        def initialize(connection, config, docker_host_ip)
+        def initialize(connection, config, docker_host)
           super(connection, config)
-          @docker_host_ip = docker_host_ip
+          @docker_host = docker_host
         end
 
         def execute!
@@ -26,7 +26,7 @@ module Spurious
               if container.json["Name"] == '/spurious-sqs' then
                 port_setup = Proc.new do
                   port = container.json["NetworkSettings"]["Ports"]['4568/tcp'].first['HostPort']
-                  Net::HTTP.get(URI("http://#{docker_host_ip}:#{port}/host-details?host=#{docker_host_ip}&port=#{port}"))
+                  Net::HTTP.get(URI("http://#{docker_host}:#{port}/host-details?host=#{docker_host}&port=#{port}"))
                 end
 
                 EM.add_timer(5) { EM.defer(port_setup) }


### PR DESCRIPTION
When running the [fake-s3](https://www.github.com/stevenjack/fake-s3) inside a docker container, the host resolution is incorrect as it tries to match the the ip of the host accessing the service against the ip that the service was run on. The issue here is that the IP reported to the container is that of the boot2docker box (or any other VM running docker), and it causes the gem to work incorrectly when using the `as_tree` functionality of the ruby-sdk and most likely other SDK's that implement the prefix functionality.
