### PR TITLE
[READY] Store PID in home dir

### DIFF
--- a/bin/spurious-server
+++ b/bin/spurious-server
@@ -12,6 +12,6 @@ require 'spurious/server/options'
 options = Spurious::Server::Options.new(ENV)
 ENV['DOCKER_HOST'] = options.ssl_docker_host
 
-Daemons.run_proc('Spurious_Server', :dir => '/tmp', :log_output => true) do
+Daemons.run_proc('.spurious-server', :dir => '~/', :log_output => true) do
   EventMachine.synchrony Spurious::Server.handle(options)
 end

--- a/bin/spurious-server
+++ b/bin/spurious-server
@@ -12,6 +12,6 @@ require 'spurious/server/options'
 options = Spurious::Server::Options.new(ENV)
 ENV['DOCKER_HOST'] = options.ssl_docker_host
 
-Daemons.run_proc('.spurious-server', :dir => '~/', :log_output => true) do
+Daemons.run_proc('.spurious-server', :dir => '~/') do
   EventMachine.synchrony Spurious::Server.handle(options)
 end


### PR DESCRIPTION
### Problem

The PID was stored in `/tmp`, this obviously caused in issue when `/tmp` was periodically cleaned out on some OS's such as OSX.

### Solution

As we can't write to `/var/run` without requesting sudo, and the daemon really doesn't need to run as sudo the solution is to store the pid in the users home directory.

The name has been changed to `.spurious-server` as this is what `daemons` uses to name the pid, and it's less intrusive as a hidden file in the home directory. 