### PR TITLE
[READY] Check docker daemon is available before starting

### DIFF
--- a/bin/spurious-server
+++ b/bin/spurious-server
@@ -12,6 +12,8 @@ require 'spurious/server/options'
 options = Spurious::Server::Options.new(ENV)
 ENV['DOCKER_HOST'] = options.ssl_docker_host
 
-Daemons.run_proc('.spurious-server', :dir => '~/') do
-  EventMachine.synchrony Spurious::Server.handle(options)
+if Spurious::Server.docker_daemon_available? ARGV[0]
+  Daemons.run_proc('.spurious-server', :dir => '~/') do
+    EventMachine.synchrony Spurious::Server.handle(options)
+  end
 end

--- a/lib/spurious/server.rb
+++ b/lib/spurious/server.rb
@@ -5,6 +5,23 @@ require "spurious/server/app"
 module Spurious
   module Server
 
+    TIMEOUT     = 5
+    SHELL_RED   = "\e[31m"
+    SHELL_GREEN = "\e[32m"
+    SHELL_CLEAR = "\e[0m"
+
+    def self.docker_daemon_available?(daemon_action)
+      if daemon_action == 'start'
+        puts "#{SHELL_GREEN} Checking docker daemon is available...#{SHELL_CLEAR}"
+        Excon.defaults[:connect_timeout] = Excon.defaults[:read_timeout] = TIMEOUT
+        !Docker.info.nil?
+      end
+      true
+    rescue Excon::Errors::SocketError, Excon::Errors::Timeout, Docker::Error::TimeoutError => e
+      puts "#{SHELL_RED} Connecting to the docker daemon (#{ENV["DOCKER_HOST"]}) failed... Check that it's running"
+      exit -1
+    end
+
     def self.handle(options)
       Proc.new do
         EventMachine.start_server(


### PR DESCRIPTION
### Problem

If the docker daemon isn't available when starting the server, the command just hangs until the default excon timeout and doesn't allude to any reason as to why it didn't start.

### Solution

Change the exon timeout and if we experience one after 5 seconds we can be fairly sure there's an issue with connecting to the docker daemon.